### PR TITLE
⬆ Update .NET SDK to 5.0 in our workflows

### DIFF
--- a/workflow-templates/dotnet-build.yml
+++ b/workflow-templates/dotnet-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.301
+          dotnet-version: 5.0.102
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/workflow-templates/dotnet-publish.yml
+++ b/workflow-templates/dotnet-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.301
+          dotnet-version: 5.0.102
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
## ✨ What's this?
Updates .NET SDK version used by GitHub action to 5.0, which is the most commonly supported SDK we use now.

## 🔍 Why do we want this?
Things might break otherwise.

## 🏗 How is it done?
Look up the available .NET versions [here](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) and pick the highest one.

### 💥 Breaking changes
None, will only apply to newly copied workflows.

### 🦋 Side effects
Libraries that use other .NET versions may need to manually adjust the version.