### PR TITLE
💬 Add a paragraph to the PR template explaining PR labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 <!-- This template is a guideline; use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->
 
 <!-- Please add a short, clear title that states what this PR changes -->
+<!-- Tag your PR with all of the following tags that are relevant:
+  * `fix` if your PR includes a fix for unintentional behavior;
+  * `feature` if your PR includes new functionality;
+  * `breaking-change` if your PR includes a change that may break existing clients;
+  * `ignore-release` if your PR should not be included in release notes (for example if it's exclusively related to maintenance and/or CI).
+If one of these tags is not available, contact somebody from the beardgame/owners team.
+-->
 
 ## ✨ What's this?
 <!-- Describe clearly and concisely what this PR changes -->


### PR DESCRIPTION
## ✨ What's this?
This PR updates the template for all future PRs with a comment about PR tags. PR tags allow us to automatically generate release notes based on merged PRs.

### 🔗 Relationships
See beardgame/utilities#255 to read more about my intent to switch to a different release creation action.

## 🔍 Why do we want this?
The more structured data we have for PRs, the more we can do with it in automation.

## 🏗 How is it done?
I do not believe there is a way to automatically add tags as with issue templates, and neither does that make much sense. This adds another item for PR authors to take a look at before sending a PR for review.

## 💡 Review hints
Feel free to squash and merge. It should automatically propagate to all organization repos.