### PR TITLE
💚 Update build workflow to incorporate latest lessons

### DIFF
--- a/workflow-templates/dotnet-build.yml
+++ b/workflow-templates/dotnet-build.yml
@@ -14,10 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core
+      - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.102
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/workflow-templates/dotnet-build.yml
+++ b/workflow-templates/dotnet-build.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           dotnet-version: |
             3.1.x
-            5.0.x
             6.0.x
       - name: Install dependencies
         run: dotnet restore

--- a/workflow-templates/dotnet-publish.yml
+++ b/workflow-templates/dotnet-publish.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.102
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -34,8 +37,9 @@ jobs:
       # Create the NuGet package
       # Note that we substr the release version to get the numbers only, without
       # the 'v' prefix.
-      - name: Pack binary
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1}
+      # TODO: ensure that you replace the library name below, and add further blocks for other libraries
+      - name: Pack Bearded.Library
+        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Library/Bearded.Library.csproj
 
       # Create a GitHub release
       - name: Create a Release

--- a/workflow-templates/dotnet-publish.yml
+++ b/workflow-templates/dotnet-publish.yml
@@ -43,15 +43,15 @@ jobs:
 
       # Create a GitHub release
       - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/*.nupkg"
 
       # Push the NuGet package to the package providers
       - name: Push release to NuGet

--- a/workflow-templates/dotnet-publish.yml
+++ b/workflow-templates/dotnet-publish.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           dotnet-version: |
             3.1.x
-            5.0.x
             6.0.x
       - name: Install dependencies
         run: dotnet restore


### PR DESCRIPTION
## ✨ What's this?
Merges back the changes from the different libraries into the main template.

## 🔍 Why do we want this?
Remain consistent and up-to-date.

## 🏗 How is it done?
Manual merge back the changes from Utilities and Graphics

### 🦋 Side effects
We probably want to switch to [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) instead, so we don't have to duplicate the workflows at all. This follow-up work is tracked in #8 

This PR also removes support for .NET 5. This is no longer a supported .NET version: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

## 💡 Review hints
Feel free to squash and merge.
