### PR TITLE
🔂 Turn workflows into reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆"
+    assignees:
+      - "tomrijnbeek"

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_call:
+
+jobs:
+  dotnet-build:
+
+    name: Build .NET
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -1,0 +1,53 @@
+on:
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      NUGET_API_KEY:
+        required: true
+
+jobs:
+  dotnet-publish:
+
+    name: Publish .NET
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            3.1.x
+            6.0.x
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-restore --verbosity normal
+
+      # The version number can be extracted from the currently checked out tag,
+      # which has the format 'refs/tags/v*'.
+      - name: Extract version number
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      # Create the NuGet package
+      # Note that we substr the release version to get the numbers only, without
+      # the 'v' prefix.
+      - name: Build NuGet packages
+        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1}
+
+      - name: Create a Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/*.nupkg"
+
+      - name: Push release to NuGet
+        run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/workflow-templates/dotnet-build.yml
+++ b/workflow-templates/dotnet-build.yml
@@ -1,4 +1,4 @@
-name: Build & Test [.NET Core]
+name: Build .NET
 
 on:
   push:
@@ -7,22 +7,5 @@ on:
     branches: [ $default-branch ]
 
 jobs:
-  build:
-
-    name: Build & Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
+  dotnet-build:
+    uses: beardgame/.github/.github/workflows/dotnet-build.yml@main

--- a/workflow-templates/dotnet-publish.yml
+++ b/workflow-templates/dotnet-publish.yml
@@ -1,4 +1,4 @@
-name: Publish [.NET Core]
+name: Publish .NET
 
 on:
   push:
@@ -6,52 +6,8 @@ on:
       - v*
 
 jobs:
-  publish:
-
-    name: Publish
-    runs-on: ubuntu-latest
-
-    steps:
-      # Build library and run tests
-      - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: |
-            3.1.x
-            6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
-
-      # Set up environment variables
-      # The version number can be extracted from the currently checked out tag,
-      # which has the format 'refs/tags/v*'.
-      - name: Extract version number
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      # Create the NuGet package
-      # Note that we substr the release version to get the numbers only, without
-      # the 'v' prefix.
-      # TODO: ensure that you replace the library name below, and add further blocks for other libraries
-      - name: Pack Bearded.Library
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Library/Bearded.Library.csproj
-
-      # Create a GitHub release
-      - name: Create a Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          name: Release ${{ env.RELEASE_VERSION }}
-          draft: false
-          prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/*.nupkg"
-
-      # Push the NuGet package to the package providers
-      - name: Push release to NuGet
-        run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+  dotnet-publish:
+    uses: beardgame/.github/.github/workflows/dotnet-publish.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## ✨ What's this?
This PR moves the current [starter workflows](https://docs.github.com/en/actions/using-workflows/using-starter-workflows) into [reusable workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).

### 🔗 Relationships
Closes #8 

## 🔍 Why do we want this?
It makes it much easier to keep workflows up-to-date. Changes to the workflow in this repository will automatically be propagated to the repositories using these jobs (unless they pin to a specific version; I don't think dependabot can automatically keep it up-to-date).

## 🏗 How is it done?
This essentially copies the contents of the started workflows into a reusable workflow. There were some minor changes made to the publish workflow to just upload all the packages again. Previously we ran into trouble because we automatically started packing projects we didn't want to pack. This can actually be fixed by setting `IsPackable` to false, which is probably a better solution anyway. I am sending a PR on the Graphics library to address this problem there.

I also added `dependabot.yml` config to keep our actions up-to-date (they are actually outdated right now).

### 🔬 Why not another way?
One of the decisions I took is to keep the reusable workflows in this repository. We could make a separate `workflows` repository, but I tried to avoid having too many repositories and I think this works just fine (though we can reconsider if necessary).

### 🦋 Side effects
We will need to update all existing repositories to change to these reusable workflows (and verify they work). We also need to ensure we aren't accidentally packing too many projects.

## 💡 Review hints
Relevant documentation is linked inline above.